### PR TITLE
fix: publish src folder for react-scripts source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "lib-es/src/index.d.ts",
   "files": [
     "lib/src",
-    "lib-es/src"
+    "lib-es/src",
+    "src"
   ],
   "scripts": {
     "build": "npm run clean && npm run build:ts",


### PR DESCRIPTION
React Scripts complains that no source maps / sources are found in the npm package for react-well-plates

```
WARNING in ./node_modules/react-well-plates/lib-es/src/WellPicker.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from 'C:\...\node_modules\react-well-plates\src\WellPicker.tsx' file: Error: ENOENT: no such file or directory, open 'C:\..\node_modules\react-well-plates\src\WellPicker.tsx'
```

This commit adds the src folder to the npm package so that react-scripts stops complaining.